### PR TITLE
Add KodeAgent to the list of core agent frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Frameworks for building and managing AI agents.
 |[CAMEL](https://github.com/camel-ai/camel)                                 |![](https://img.shields.io/github/stars/camel-ai/camel)              |Multi-agent framework for communicative agents research                                   |
 |[Strands Agents SDK](https://github.com/strands-agents/sdk-python)         |![](https://img.shields.io/github/stars/strands-agents/sdk-python)   |AWS-backed model-driven agent SDK with MCP and multi-provider support                     |
 |[Summoner](https://github.com/Summoner-Network/summoner-agents) | ![](https://img.shields.io/github/stars/Summoner-Network/summoner-agents) | Agent-to-agent networking for server-decoupled agents over long-lived TCP sessions (Python/Rust), 50+ runnable templates |
+|[KodeAgent](https://github.com/barun-saha/kodeagent)  | ![](https://img.shields.io/github/stars/barun-saha/kodeagent)  | The Minimal Agent Engine to build ReAct & CodeAct agents, with support for code sandbox and observability  |
 
 ---
 


### PR DESCRIPTION
Hello,

I'd like to add [KodeAgent](https://github.com/barun-saha/kodeagent) to the list of agent frameworks. KodeAgent is a minimalistic approach to build robust ReAct & COdeAct agents, complete with code sandbox and observability.