### PR TITLE
Add ShopSavvy Desktop to Web Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Agents designed for specific tasks or industries.
 | [Firecrawl](https://github.com/firecrawl/firecrawl)       | ![](https://img.shields.io/github/stars/firecrawl/firecrawl)     | Turn websites into LLM-ready markdown or structured data         |
 | [Crawl4AI](https://github.com/unclecode/crawl4ai)         | ![](https://img.shields.io/github/stars/unclecode/crawl4ai)      | Open-source LLM-friendly web crawler and scraper                 |
 | [Stagehand](https://github.com/browserbase/stagehand)     | ![](https://img.shields.io/github/stars/browserbase/stagehand)   | AI browser automation framework with natural language and code   |
+| [ShopSavvy Desktop](https://shopsavvy.com/desktop)        | -                                                                | Autonomous AI shopping agent for Mac, Windows, and Linux that auto-buys products at target prices, navigates retailer checkouts, and monitors prices in the background |
 
 ### 🗣️ Programming Language Agents
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Agents designed for specific tasks or industries.
 | [Firecrawl](https://github.com/firecrawl/firecrawl)       | ![](https://img.shields.io/github/stars/firecrawl/firecrawl)     | Turn websites into LLM-ready markdown or structured data         |
 | [Crawl4AI](https://github.com/unclecode/crawl4ai)         | ![](https://img.shields.io/github/stars/unclecode/crawl4ai)      | Open-source LLM-friendly web crawler and scraper                 |
 | [Stagehand](https://github.com/browserbase/stagehand)     | ![](https://img.shields.io/github/stars/browserbase/stagehand)   | AI browser automation framework with natural language and code   |
-| [ShopSavvy Desktop](https://shopsavvy.com/desktop)        | -                                                                | Autonomous AI shopping agent for Mac, Windows, and Linux that auto-buys products at target prices, navigates retailer checkouts, and monitors prices in the background |
+| [ShopSavvy Desktop](https://shopsavvy.com/desktop)        | -                                                                | Autonomous AI shopping agent for desktop price tracking and auto-purchasing |
 
 ### 🗣️ Programming Language Agents
 


### PR DESCRIPTION
Adds ShopSavvy Desktop to the Web Agents section. It's a desktop shopping agent for Mac, Windows, and Linux that navigates retailer sites, handles checkout, and tracks prices in the background.