### PR TITLE
Add Dakera to Memory section

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Tools and systems for managing AI agents.
 | [Mem0](https://github.com/mem0ai/mem0)                       | ![](https://img.shields.io/github/stars/mem0ai/mem0)        | Universal memory layer for AI agents   |
 | [ChromaDB](https://github.com/chroma-core/chroma)            | ![](https://img.shields.io/github/stars/chroma-core/chroma) | Vector DB for memory/context           |
 | [Weaviate](https://github.com/weaviate/weaviate)             | ![](https://img.shields.io/github/stars/weaviate/weaviate)  | Scalable vector DB for semantic memory |
-| [Dakera](https://github.com/Dakera-AI/dakera-docs)                | ![](https://img.shields.io/github/stars/Dakera-AI/dakera)   | Production-ready persistent memory layer with hybrid BM25 + vector retrieval and temporal reasoning |
+| [Dakera](https://github.com/Dakera-AI/dakera-docs)                | ![](https://img.shields.io/github/stars/Dakera-AI/dakera-docs)   | Production-ready persistent memory layer with hybrid BM25 + vector retrieval and temporal reasoning |
 
 ### 📊 Evaluation
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Tools and systems for managing AI agents.
 | [Mem0](https://github.com/mem0ai/mem0)                       | ![](https://img.shields.io/github/stars/mem0ai/mem0)        | Universal memory layer for AI agents   |
 | [ChromaDB](https://github.com/chroma-core/chroma)            | ![](https://img.shields.io/github/stars/chroma-core/chroma) | Vector DB for memory/context           |
 | [Weaviate](https://github.com/weaviate/weaviate)             | ![](https://img.shields.io/github/stars/weaviate/weaviate)  | Scalable vector DB for semantic memory |
+| [Dakera](https://github.com/Dakera-AI/dakera)                | ![](https://img.shields.io/github/stars/Dakera-AI/dakera)   | Production-ready persistent memory layer with hybrid BM25 + vector retrieval and temporal reasoning |
 
 ### 📊 Evaluation
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Tools and systems for managing AI agents.
 | [Mem0](https://github.com/mem0ai/mem0)                       | ![](https://img.shields.io/github/stars/mem0ai/mem0)        | Universal memory layer for AI agents   |
 | [ChromaDB](https://github.com/chroma-core/chroma)            | ![](https://img.shields.io/github/stars/chroma-core/chroma) | Vector DB for memory/context           |
 | [Weaviate](https://github.com/weaviate/weaviate)             | ![](https://img.shields.io/github/stars/weaviate/weaviate)  | Scalable vector DB for semantic memory |
-| [Dakera](https://github.com/Dakera-AI/dakera)                | ![](https://img.shields.io/github/stars/Dakera-AI/dakera)   | Production-ready persistent memory layer with hybrid BM25 + vector retrieval and temporal reasoning |
+| [Dakera](https://github.com/Dakera-AI/dakera-docs)                | ![](https://img.shields.io/github/stars/Dakera-AI/dakera)   | Production-ready persistent memory layer with hybrid BM25 + vector retrieval and temporal reasoning |
 
 ### 📊 Evaluation
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Tools and systems for managing AI agents.
 | [Mem0](https://github.com/mem0ai/mem0)                       | ![](https://img.shields.io/github/stars/mem0ai/mem0)        | Universal memory layer for AI agents   |
 | [ChromaDB](https://github.com/chroma-core/chroma)            | ![](https://img.shields.io/github/stars/chroma-core/chroma) | Vector DB for memory/context           |
 | [Weaviate](https://github.com/weaviate/weaviate)             | ![](https://img.shields.io/github/stars/weaviate/weaviate)  | Scalable vector DB for semantic memory |
-| [Dakera](https://github.com/Dakera-AI/dakera-docs)                | ![](https://img.shields.io/github/stars/Dakera-AI/dakera-docs)   | Production-ready persistent memory layer with hybrid BM25 + vector retrieval and temporal reasoning |
+| [Dakera](https://github.com/dakera-ai/dakera-deploy)                | ![](https://img.shields.io/github/stars/dakera-ai/dakera-deploy)   | Production-ready persistent memory layer with hybrid BM25 + vector retrieval and temporal reasoning |
 
 ### 📊 Evaluation
 


### PR DESCRIPTION
Adds [Dakera](https://github.com/Dakera-AI/dakera-docs) to the 🧠 Memory section.

Dakera is a production-ready persistent memory layer for AI agents. Unlike vector databases alone, it provides:
- **Hybrid retrieval**: BM25 + semantic vector search with importance weighting
- **Temporal reasoning**: time-aware memory decay and recency scoring
- **Multi-tenant**: namespace isolation for multi-user agent deployments
- **Framework integrations**: LangChain, LlamaIndex, CrewAI, AutoGen

A natural complement to the vector DBs already listed — Dakera adds the agent-memory orchestration layer on top.

GitHub: https://github.com/Dakera-AI/dakera-docs | Docs: https://docs.dakera.ai