### PR TITLE
Add Dakera to Memory section

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Tools and systems for managing AI agents.
 | [ChromaDB](https://github.com/chroma-core/chroma)            | ![](https://img.shields.io/github/stars/chroma-core/chroma) | Vector DB for memory/context           |
 | [Weaviate](https://github.com/weaviate/weaviate)             | ![](https://img.shields.io/github/stars/weaviate/weaviate)  | Scalable vector DB for semantic memory |
 
+| [Dakera](https://github.com/dakera-ai/dakera-deploy)         | ![](https://img.shields.io/github/stars/dakera-ai/dakera-deploy) | Self-hostable persistent memory and knowledge layer for AI agents with MCP support |
 ### 📊 Evaluation
 
 | Name                                                              | Stars                                                                       | Description                                                                                       |


### PR DESCRIPTION
## Description

Adds [Dakera](https://github.com/dakera-ai/dakera-deploy) — a production-ready, self-hosted agent memory server.

**Key features:**
- Hybrid BM25 + HNSW vector retrieval for high-recall semantic search
- Decay-weighted recall (importance fades over time, like human memory)
- Multi-agent namespacing with per-namespace isolation
- MCP-native integration — works with Claude Code, Cursor, Windsurf, and any MCP client
- SDKs for Python, TypeScript, Go, and Rust

Open-source (Apache 2.0), self-hosted, production-ready.
