### PR TITLE
feat: add TWZRD Agent Intel to Security & Governance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Tools and systems for managing AI agents.
 | [NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails)                      | ![](https://img.shields.io/github/stars/NVIDIA/NeMo-Guardrails)             | Programmable guardrails for LLM-based conversational systems                               |
 | [LLM Guard](https://github.com/protectai/llm-guard)                               | ![](https://img.shields.io/github/stars/protectai/llm-guard)                | Security toolkit for scanning and sanitizing LLM prompts and outputs                       |
 | [Polaxis](https://github.com/nishant6118/Polaxis-SDK-MCP)                         | ![](https://img.shields.io/github/stars/nishant6118/Polaxis-SDK-MCP)        | Pre-execution runtime firewall for AI agents — 7-layer threat detection and spend controls |
+| [TWZRD Agent Intel](https://intel.twzrd.xyz)                                         | ![](https://img.shields.io/badge/MCP-free-brightgreen) |
 
 ---
 


### PR DESCRIPTION
## Description

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the Security & Governance section.

TWZRD Agent Intel is an on-chain trust scoring service for AI agent wallets on Solana. It provides MCP tools that let agents verify each other's identity and reputation before executing x402 micropayments — a core primitive for secure agent-to-agent interactions.

**MCP Tools (free):**
- `score_agent(wallet)` — trust score + on-chain reputation
- `preflight_check(wallet)` — verify agent identity before payment
- `get_trust_receipt(wallet)` — paid x402 micropayment receipt

**Config:**
```json
{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
```

Fits naturally in Security & Governance alongside Garak, Guardrails AI, and LLM Guard — focused on agent identity and trust rather than LLM content safety.