### PR TITLE
feat: add NotFair — open-source Claude Code marketing agent skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ _A curated list of frameworks, tools, and resources for building and deploying A
   - [💻 Coding Agents](#-coding-agents)
   - [🔬 Research Agents](#-research-agents)
   - [🎨 Creative Agents](#-creative-agents)
+  - [📈 Marketing Agents](#-marketing-agents)
   - [🌐 Web Agents](#-web-agents)
   - [🗣️ Programming Language Agents](#-programming-language-agents)
 - [⚙️ Agent Operations](#-agent-operations)
@@ -125,6 +126,12 @@ Agents designed for specific tasks or industries.
 | -------------------------------------------------- | ------------------------------------------------------------ | --------------------------------------- |
 | [ShortGPT](https://github.com/RayVentura/ShortGPT) | ![](https://img.shields.io/github/stars/RayVentura/ShortGPT) | Short-form video generation agent       |
 | [AI-town](https://github.com/a16z-infra/ai-town)   | ![](https://img.shields.io/github/stars/a16z-infra/ai-town)  | Virtual world simulation with AI agents |
+
+### 📈 Marketing Agents
+
+| Name                                                              | Stars                                                              | Description                                                                                                                                                          |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [NotFair](https://github.com/nowork-studio/NotFair)               | ![](https://img.shields.io/github/stars/nowork-studio/NotFair)     | Open-source Claude Code agent skills for SEO, Google Ads, and Meta Ads; connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP |
 
 ### 🌐 Web Agents
 


### PR DESCRIPTION
Hi, thank you for maintaining this excellent list!

I'd like to add **[NotFair](https://github.com/nowork-studio/NotFair)** (~2.9k stars, MIT license) under a new **Marketing Agents** subsection in Specialized Agents.

NotFair is a set of open-source Claude Code agent skills for SEO, Google Ads, and Meta Ads work. It connects to live account data through the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP — so the agents can autonomously run audits, find wasted spend, research keywords, generate schema markup, and more against real data. Skill areas include SEO analysis, content writing, Google Ads management, and Meta Ads (Facebook/Instagram) optimization.

It fits the "Specialized Agents" pattern already established in the list (agents built for a specific domain), similar to how Coding Agents and Research Agents are grouped. Since there's no marketing category yet, I added a small Marketing Agents subsection following the same table format as the rest of the file.

Happy to reword the description, move it to a different section, or trim anything that doesn't fit your style — just let me know.