### PR TITLE
Add rust-norion

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Tools and systems for managing AI agents.
 | [NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails)                      | ![](https://img.shields.io/github/stars/NVIDIA/NeMo-Guardrails)             | Programmable guardrails for LLM-based conversational systems                               |
 | [LLM Guard](https://github.com/protectai/llm-guard)                               | ![](https://img.shields.io/github/stars/protectai/llm-guard)                | Security toolkit for scanning and sanitizing LLM prompts and outputs                       |
 | [Polaxis](https://github.com/nishant6118/Polaxis-SDK-MCP)                         | ![](https://img.shields.io/github/stars/nishant6118/Polaxis-SDK-MCP)        | Pre-execution runtime firewall for AI agents - 7-layer threat detection and spend controls |
+| [rust-norion](https://github.com/yanghao1143/rust-norion)                         | ![](https://img.shields.io/github/stars/yanghao1143/rust-norion)            | Rust prototype for AI runtime-control boundaries with routing, evidence gates, and audit traces |
 
 ---
 


### PR DESCRIPTION
Adds rust-norion to Security & Governance.

Why this fits:
- rust-norion is an open-source Rust prototype focused on runtime-control boundaries around AI agents and inference workflows;
- relevant controls include routing, evidence gates, rollback, and audit traces;
- the entry follows the existing table format with a GitHub stars badge and short description.

Scope note: rust-norion is an early prototype, not a production inference engine.