### PR TITLE
Website improvements: hero, theme toggle, mobile header, and polish

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,6 +136,7 @@
       border-radius: 999px;
     }
     #status { color: var(--text-muted); padding: 2rem 0; text-align: center; }
+    #status:empty { display: none; }
     footer {
       max-width: 1200px;
       margin: 0 auto;

--- a/index.html
+++ b/index.html
@@ -54,6 +54,53 @@
     a { color: var(--accent); text-decoration: none; }
     a:hover { text-decoration: underline; }
 
+    .hero {
+      text-align: center;
+      padding: 2.75rem 1.5rem 2.25rem;
+      background: linear-gradient(180deg, var(--accent-soft), var(--bg));
+    }
+    .hero h1 { font-size: 1.9rem; font-weight: 800; }
+    .tagline {
+      max-width: 38rem;
+      margin: 0.5rem auto 0;
+      color: var(--text-muted);
+      font-size: 0.95rem;
+    }
+    .hero-stats {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      justify-content: center;
+      margin-top: 1rem;
+      font-size: 0.85rem;
+      color: var(--text-muted);
+    }
+    .hero-stats .stat {
+      padding: 0.2rem 0.75rem;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 999px;
+    }
+    .hero-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.6rem;
+      justify-content: center;
+      margin-top: 1.1rem;
+    }
+    .btn {
+      padding: 0.5rem 1.1rem;
+      font-size: 0.9rem;
+      font-weight: 600;
+      color: var(--text);
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+    }
+    .btn:hover { text-decoration: none; border-color: var(--accent); }
+    .btn-primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+    .btn-primary:hover { opacity: 0.92; }
+
     header {
       position: sticky;
       top: 0;
@@ -63,28 +110,19 @@
       padding: 1rem 1.5rem 0.9rem;
     }
     .header-inner { max-width: 1200px; margin: 0 auto; }
-    .header-top {
-      display: flex;
-      flex-wrap: wrap;
-      align-items: baseline;
-      gap: 0.4rem 1rem;
-      margin-bottom: 0.75rem;
-    }
-    h1 { font-size: 1.25rem; font-weight: 700; }
-    .subtitle { color: var(--text-muted); font-size: 0.9rem; flex: 1 1 16rem; }
-    .gh-link { font-size: 0.9rem; white-space: nowrap; }
+    .search-row { display: flex; gap: 0.5rem; }
     #theme-toggle {
-      padding: 0.15rem 0.5rem;
-      font-size: 0.9rem;
+      padding: 0.15rem 0.65rem;
+      font-size: 0.95rem;
       background: var(--surface);
       border: 1px solid var(--border);
-      border-radius: 999px;
+      border-radius: 8px;
       cursor: pointer;
       line-height: 1.4;
     }
     #theme-toggle:hover { border-color: var(--accent); }
     #search {
-      width: 100%;
+      flex: 1;
       padding: 0.6rem 0.9rem;
       font-size: 0.95rem;
       color: var(--text);
@@ -163,7 +201,8 @@
     #status { color: var(--text-muted); padding: 2rem 0; text-align: center; }
     #status:empty { display: none; }
     @media (max-width: 640px) {
-      .subtitle { display: none; }
+      .hero { padding: 2rem 1.5rem 1.75rem; }
+      .hero h1 { font-size: 1.5rem; }
       .chips {
         flex-wrap: nowrap;
         overflow-x: auto;
@@ -187,15 +226,22 @@
   </style>
 </head>
 <body>
+  <section class="hero">
+    <h1>🤖 Awesome AI Agents</h1>
+    <p class="tagline">A curated, searchable directory of frameworks, tools, and resources for building and deploying AI agents</p>
+    <div class="hero-stats" id="hero-stats"></div>
+    <div class="hero-actions">
+      <a class="btn btn-primary" href="https://github.com/NipunaRanasinghe/awesome-ai-agents">⭐ Star on GitHub</a>
+      <a class="btn" href="https://github.com/NipunaRanasinghe/awesome-ai-agents/blob/main/CONTRIBUTING.md">Contribute</a>
+    </div>
+  </section>
+
   <header>
     <div class="header-inner">
-      <div class="header-top">
-        <h1>🤖 Awesome AI Agents</h1>
-        <span class="subtitle">A curated, searchable directory of frameworks, tools, and resources for building AI agents</span>
-        <a class="gh-link" href="https://github.com/NipunaRanasinghe/awesome-ai-agents">GitHub&nbsp;↗</a>
+      <div class="search-row">
+        <input id="search" type="search" placeholder="Search by name, description, or language…" autocomplete="off">
         <button id="theme-toggle" title="Toggle light/dark mode" aria-label="Toggle light/dark mode"></button>
       </div>
-      <input id="search" type="search" placeholder="Search by name, description, or language…" autocomplete="off">
       <div class="chips" id="chips"></div>
     </div>
   </header>
@@ -353,6 +399,9 @@
       .then(r => { if (!r.ok) throw new Error(r.status); return r.text(); })
       .then(md => {
         sections = parseReadme(md);
+        const total = sections.reduce((n, s) => n + s.items.length, 0);
+        $('hero-stats').innerHTML =
+          `<span class="stat">${total} projects</span><span class="stat">${sections.length} categories</span>`;
         renderChips();
         render();
       })

--- a/index.html
+++ b/index.html
@@ -207,6 +207,25 @@
     }
     #status { color: var(--text-muted); padding: 2rem 0; text-align: center; }
     #status:empty { display: none; }
+    #back-to-top {
+      position: fixed;
+      right: 1.25rem;
+      bottom: 1.25rem;
+      width: 2.6rem;
+      height: 2.6rem;
+      font-size: 1.1rem;
+      color: var(--text);
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 50%;
+      box-shadow: var(--shadow);
+      cursor: pointer;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.2s;
+    }
+    #back-to-top.visible { opacity: 1; pointer-events: auto; }
+    #back-to-top:hover { border-color: var(--accent); color: var(--accent); }
     @media (max-width: 640px) {
       .hero { padding: 2rem 1.5rem 1.75rem; }
       .hero h1 { font-size: 1.5rem; }
@@ -258,6 +277,8 @@
     <div id="status">Loading the list…</div>
     <div id="results"></div>
   </main>
+
+  <button id="back-to-top" title="Back to top" aria-label="Back to top">↑</button>
 
   <footer>
     Generated live from the repository's
@@ -431,6 +452,11 @@
     });
     matchMedia('(prefers-color-scheme: dark)').addEventListener('change', updateToggleIcon);
     updateToggleIcon();
+
+    window.addEventListener('scroll', () => {
+      $('back-to-top').classList.toggle('visible', window.scrollY > 600);
+    }, { passive: true });
+    $('back-to-top').addEventListener('click', () => window.scrollTo({ top: 0, behavior: 'smooth' }));
 
     fetch('README.md')
       .then(r => { if (!r.ok) throw new Error(r.status); return r.text(); })

--- a/index.html
+++ b/index.html
@@ -391,9 +391,13 @@
     }
 
     function renderChips() {
-      const names = ['All', ...sections.map(s => s.title)];
-      $('chips').innerHTML = names.map(n =>
-        `<button class="chip${n === activeCategory ? ' active' : ''}" data-cat="${esc(n)}">${esc(n)}</button>`).join('');
+      const total = sections.reduce((n, s) => n + s.items.length, 0);
+      const chips = [
+        { name: 'All', count: total },
+        ...sections.map(s => ({ name: s.title, count: s.items.length })),
+      ];
+      $('chips').innerHTML = chips.map(c =>
+        `<button class="chip${c.name === activeCategory ? ' active' : ''}" data-cat="${esc(c.name)}">${esc(c.name)} · ${c.count}</button>`).join('');
     }
 
     $('chips').addEventListener('click', e => {

--- a/index.html
+++ b/index.html
@@ -331,7 +331,23 @@
 
     const $ = id => document.getElementById(id);
     const esc = s => s.replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+    const slug = s => s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
     let sections = [], activeCategory = 'All';
+
+    function syncUrl() {
+      const q = $('search').value.trim();
+      let hash = activeCategory === 'All' ? '' : slug(activeCategory);
+      if (q) hash += '?q=' + encodeURIComponent(q);
+      history.replaceState(null, '', hash ? '#' + hash : location.pathname + location.search);
+    }
+
+    function applyUrlState() {
+      const [cat, qs] = location.hash.slice(1).split('?');
+      const match = sections.find(s => slug(s.title) === cat);
+      if (match) activeCategory = match.title;
+      const q = new URLSearchParams(qs || '').get('q');
+      if (q) $('search').value = q;
+    }
 
     function card(item, showCategory) {
       const badge = item.badge
@@ -371,6 +387,7 @@
         ? `Showing ${shown} of ${total} entries` : `${total} entries`;
       $('results').innerHTML = html.join('');
       $('status').textContent = html.length ? '' : 'No entries match your search.';
+      syncUrl();
     }
 
     function renderChips() {
@@ -409,6 +426,7 @@
         const total = sections.reduce((n, s) => n + s.items.length, 0);
         $('hero-stats').innerHTML =
           `<span class="stat">${total} projects</span><span class="stat">${sections.length} categories</span>`;
+        applyUrlState();
         renderChips();
         render();
       })

--- a/index.html
+++ b/index.html
@@ -5,6 +5,13 @@
   <title>Awesome AI Agents</title>
   <meta name="description" content="A curated, searchable directory of frameworks, tools, and resources for building and deploying AI agents">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🤖</text></svg>">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Awesome AI Agents">
+  <meta property="og:description" content="A curated, searchable directory of frameworks, tools, and resources for building and deploying AI agents">
+  <meta property="og:url" content="https://nipunaranasinghe.github.io/awesome-ai-agents/">
+  <meta property="og:image" content="https://nipunaranasinghe.github.io/awesome-ai-agents/resources/images/image.png">
+  <meta name="twitter:card" content="summary_large_image">
   <script>
     const savedTheme = localStorage.getItem('theme');
     if (savedTheme) document.documentElement.dataset.theme = savedTheme;

--- a/index.html
+++ b/index.html
@@ -464,7 +464,7 @@
         sections = parseReadme(md);
         const total = sections.reduce((n, s) => n + s.items.length, 0);
         $('hero-stats').innerHTML =
-          `<span class="stat">${total} projects</span><span class="stat">${sections.length} categories</span>`;
+          `<span class="stat">${total} entries</span><span class="stat">${sections.length} categories</span>`;
         applyUrlState();
         renderChips();
         render();

--- a/index.html
+++ b/index.html
@@ -404,6 +404,15 @@
       render();
     });
     $('search').addEventListener('input', render);
+    document.addEventListener('keydown', e => {
+      if (e.key === '/' && document.activeElement !== $('search')) {
+        e.preventDefault();
+        $('search').focus();
+      } else if (e.key === 'Escape' && $('search').value) {
+        $('search').value = '';
+        render();
+      }
+    });
 
     function isDark() {
       const t = document.documentElement.dataset.theme;

--- a/index.html
+++ b/index.html
@@ -137,6 +137,20 @@
     }
     #status { color: var(--text-muted); padding: 2rem 0; text-align: center; }
     #status:empty { display: none; }
+    @media (max-width: 640px) {
+      .subtitle { display: none; }
+      .chips {
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: none;
+        margin-left: -1.5rem;
+        margin-right: -1.5rem;
+        padding: 0 1.5rem;
+      }
+      .chips::-webkit-scrollbar { display: none; }
+      .chip { flex: 0 0 auto; }
+    }
     footer {
       max-width: 1200px;
       margin: 0 auto;

--- a/index.html
+++ b/index.html
@@ -341,7 +341,7 @@
         item.lang ? `<span class="tag">${esc(item.lang)}</span>` : '',
       ].join('');
       const name = item.url
-        ? `<a class="card-name" href="${esc(item.url)}">${esc(item.name)}</a>`
+        ? `<a class="card-name" href="${esc(item.url)}" target="_blank" rel="noopener">${esc(item.name)}</a>`
         : `<span class="card-name">${esc(item.name)}</span>`;
       return `<div class="card">
         <div class="card-head">${name}${badge}</div>

--- a/index.html
+++ b/index.html
@@ -254,17 +254,20 @@
     const esc = s => s.replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
     let sections = [], activeCategory = 'All';
 
-    function card(item) {
+    function card(item, showCategory) {
       const badge = item.badge
         ? `<span class="card-badge"><img src="${esc(item.badge)}" alt="GitHub stars" loading="lazy"></span>` : '';
-      const lang = item.lang ? `<span class="tag">${esc(item.lang)}</span>` : '';
+      const tags = [
+        showCategory ? `<span class="tag">${esc(item.category)}</span>` : '',
+        item.lang ? `<span class="tag">${esc(item.lang)}</span>` : '',
+      ].join('');
       const name = item.url
         ? `<a class="card-name" href="${esc(item.url)}">${esc(item.name)}</a>`
         : `<span class="card-name">${esc(item.name)}</span>`;
       return `<div class="card">
         <div class="card-head">${name}${badge}</div>
         <div class="card-desc">${esc(item.desc)}</div>
-        <div class="card-tags"><span class="tag">${esc(item.category)}</span>${lang}</div>
+        ${tags ? `<div class="card-tags">${tags}</div>` : ''}
       </div>`;
     }
 
@@ -282,7 +285,7 @@
         shown += items.length;
         html.push(`<h2 class="section-title">${esc(section.title)}</h2>`);
         if (section.blurb) html.push(`<p class="section-blurb">${esc(section.blurb)}</p>`);
-        html.push(`<div class="grid">${items.map(card).join('')}</div>`);
+        html.push(`<div class="grid">${items.map(i => card(i, !!q)).join('')}</div>`);
       }
 
       $('count').textContent = q || activeCategory !== 'All'

--- a/index.html
+++ b/index.html
@@ -5,6 +5,10 @@
   <title>Awesome AI Agents</title>
   <meta name="description" content="A curated, searchable directory of frameworks, tools, and resources for building and deploying AI agents">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <script>
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme) document.documentElement.dataset.theme = savedTheme;
+  </script>
   <style>
     :root {
       --bg: #f6f7f9;
@@ -17,8 +21,19 @@
       --tag-bg: #f0f2f5;
       --shadow: 0 1px 3px rgba(20, 26, 40, 0.06);
     }
+    :root[data-theme="dark"] {
+      --bg: #14171c;
+      --surface: #1d2129;
+      --text: #e8eaee;
+      --text-muted: #9aa3b0;
+      --border: #2c313b;
+      --accent: #8b96f0;
+      --accent-soft: #262c45;
+      --tag-bg: #262b34;
+      --shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+    }
     @media (prefers-color-scheme: dark) {
-      :root {
+      :root:not([data-theme="light"]) {
         --bg: #14171c;
         --surface: #1d2129;
         --text: #e8eaee;
@@ -58,6 +73,16 @@
     h1 { font-size: 1.25rem; font-weight: 700; }
     .subtitle { color: var(--text-muted); font-size: 0.9rem; flex: 1 1 16rem; }
     .gh-link { font-size: 0.9rem; white-space: nowrap; }
+    #theme-toggle {
+      padding: 0.15rem 0.5rem;
+      font-size: 0.9rem;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      cursor: pointer;
+      line-height: 1.4;
+    }
+    #theme-toggle:hover { border-color: var(--accent); }
     #search {
       width: 100%;
       padding: 0.6rem 0.9rem;
@@ -168,6 +193,7 @@
         <h1>🤖 Awesome AI Agents</h1>
         <span class="subtitle">A curated, searchable directory of frameworks, tools, and resources for building AI agents</span>
         <a class="gh-link" href="https://github.com/NipunaRanasinghe/awesome-ai-agents">GitHub&nbsp;↗</a>
+        <button id="theme-toggle" title="Toggle light/dark mode" aria-label="Toggle light/dark mode"></button>
       </div>
       <input id="search" type="search" placeholder="Search by name, description, or language…" autocomplete="off">
       <div class="chips" id="chips"></div>
@@ -308,6 +334,20 @@
       render();
     });
     $('search').addEventListener('input', render);
+
+    function isDark() {
+      const t = document.documentElement.dataset.theme;
+      return t ? t === 'dark' : matchMedia('(prefers-color-scheme: dark)').matches;
+    }
+    function updateToggleIcon() { $('theme-toggle').textContent = isDark() ? '☀️' : '🌙'; }
+    $('theme-toggle').addEventListener('click', () => {
+      const next = isDark() ? 'light' : 'dark';
+      document.documentElement.dataset.theme = next;
+      localStorage.setItem('theme', next);
+      updateToggleIcon();
+    });
+    matchMedia('(prefers-color-scheme: dark)').addEventListener('change', updateToggleIcon);
+    updateToggleIcon();
 
     fetch('README.md')
       .then(r => { if (!r.ok) throw new Error(r.status); return r.text(); })


### PR DESCRIPTION
Implements the improvement points from the site review, one commit per fix:

1. **Hide status element when empty** — removes the dead vertical gap under the entry count
2. **Collapse chip filters to one scrollable row on mobile** — sticky header no longer eats ~40% of a phone viewport
3. **Show category tag on cards only during search** — tags no longer repeat the section heading on every card
4. **Add manual light/dark theme toggle** — sun/moon button, persists in `localStorage`, defaults to the system scheme
5. **Add hero landing section** — big title, tagline, live stat pills (entries/categories computed from the parsed data), "Star on GitHub" and "Contribute" buttons; branding moves out of the sticky header, which now holds only search + chips
6. **Add favicon and social sharing meta tags** — emoji SVG favicon, `og:`/`twitter:` tags using the repo logo
7. **Open entry links in a new tab** — keeps filter state when visiting a project
8. **Sync category and search query to shareable URL hash** — e.g. `#coding-agents?q=code` restores the filtered view
9. **Focus search with `/` and clear with `Esc`**
10. **Show entry counts on category chips** — e.g. "Coding Agents · 12"
11. **Add back-to-top button** — appears after scrolling past 600px

Verified locally with headless Chrome screenshots: dark, forced-light (`data-theme` override), 390px mobile, and the deep-link state.