### PR TITLE
Add auto-generated changelog

### DIFF
--- a/.github/scripts/update_changelog.py
+++ b/.github/scripts/update_changelog.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Prepend README entry changes between two commits to CHANGELOG.md.
+
+Usage: update_changelog.py <base-sha> <head-sha> [--date YYYY-MM-DD]
+
+Reads the README.md diff between the two commits, extracts added and
+removed table entries (rows of the form `| [Name](url) | ... |`), and
+writes them under a date heading in CHANGELOG.md. Rows whose link is
+unchanged (formatting-only edits) are ignored; rows where the same name
+appears with a different URL are recorded as link updates.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ENTRY_ROW = re.compile(r"^\| *\[([^\]]+)\]\((https?://[^)\s]+)\)")
+HEADING = re.compile(r"^(#{2,3}) +(.*\S)")
+
+CHANGELOG = Path("CHANGELOG.md")
+HEADER = (
+    "# Changelog\n"
+    "\n"
+    "Entries added to or removed from the list, generated automatically "
+    "from README changes on each merge to main. Newest first.\n"
+)
+
+
+def git(*args):
+    return subprocess.run(
+        ["git", *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def diff_entries(base, head):
+    """Return ({url: name} added, {url: name} removed) between two commits."""
+    diff = git("diff", base, head, "--", "README.md")
+    added, removed = {}, {}
+    for line in diff.splitlines():
+        if line.startswith("+"):
+            m = ENTRY_ROW.match(line[1:])
+            if m:
+                added[m.group(2)] = m.group(1)
+        elif line.startswith("-"):
+            m = ENTRY_ROW.match(line[1:])
+            if m:
+                removed[m.group(2)] = m.group(1)
+    # Same URL on both sides = formatting-only change; drop it.
+    for url in set(added) & set(removed):
+        del added[url]
+        del removed[url]
+    return added, removed
+
+
+def section_map(head):
+    """Map entry URL -> nearest preceding section heading in README at head."""
+    sections = {}
+    current = ""
+    for line in git("show", f"{head}:README.md").splitlines():
+        h = HEADING.match(line)
+        if h:
+            current = h.group(2)
+            continue
+        m = ENTRY_ROW.match(line)
+        if m:
+            sections[m.group(2)] = current
+    return sections
+
+
+def build_lines(added, removed, sections):
+    lines = []
+    # Same name on both sides with different URLs = repo moved/renamed.
+    renamed = {
+        name: url
+        for url, name in removed.items()
+        if name in added.values()
+    }
+    for url, name in sorted(added.items(), key=lambda kv: kv[1].lower()):
+        if name in renamed:
+            lines.append(f"- Updated [{name}]({url}) link (repo moved)")
+        elif sections.get(url):
+            lines.append(f"- Added [{name}]({url}) to {sections[url]}")
+        else:
+            lines.append(f"- Added [{name}]({url})")
+    for url, name in sorted(removed.items(), key=lambda kv: kv[1].lower()):
+        if name not in renamed:
+            lines.append(f"- Removed {name}")
+    return lines
+
+
+def update_changelog(date, lines):
+    text = CHANGELOG.read_text() if CHANGELOG.exists() else HEADER
+    date_heading = f"## {date}"
+    body = text.splitlines()
+    if date_heading in body:
+        # Merge into the existing section for this date, skipping duplicates.
+        start = body.index(date_heading)
+        i = start + 1
+        while i < len(body) and not body[i].startswith("## "):
+            i += 1
+        # Back up over the section's trailing blank lines.
+        while i - 1 > start + 1 and body[i - 1] == "":
+            i -= 1
+        existing = set(body[start:i])
+        body[i:i] = [l for l in lines if l not in existing]
+    else:
+        # Insert a new date section before the first existing one.
+        insert_at = next(
+            (i for i, l in enumerate(body) if l.startswith("## ")), len(body)
+        )
+        if insert_at == len(body) and body and body[-1] != "":
+            body.append("")
+            insert_at += 1
+        body[insert_at:insert_at] = [date_heading, ""] + lines + [""]
+    CHANGELOG.write_text("\n".join(body).rstrip() + "\n")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("base")
+    parser.add_argument("head")
+    parser.add_argument("--date", help="YYYY-MM-DD; defaults to head commit date")
+    args = parser.parse_args()
+
+    date = args.date or git(
+        "log", "-1", "--format=%cs", args.head
+    ).strip()
+    added, removed = diff_entries(args.base, args.head)
+    if not added and not removed:
+        print("No entry changes; changelog untouched.")
+        return
+    lines = build_lines(added, removed, section_map(args.head))
+    update_changelog(date, lines)
+    print(f"Recorded {len(lines)} change(s) under {date}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,42 @@
+name: Changelog
+
+on:
+  push:
+    branches: [main]
+    paths: [README.md]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: changelog
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Update CHANGELOG.md
+        run: |
+          BASE="${{ github.event.before }}"
+          if [ -z "$BASE" ] || ! git cat-file -e "$BASE" 2>/dev/null; then
+            BASE=$(git rev-parse HEAD^)
+          fi
+          python3 .github/scripts/update_changelog.py "$BASE" "${{ github.sha }}"
+
+      - name: Commit and push
+        run: |
+          if git diff --quiet CHANGELOG.md; then
+            echo "No changelog changes to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git commit -m "Update changelog"
+          git pull --rebase origin main
+          git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,68 @@
+# Changelog
+
+Entries added to or removed from the list, generated automatically from README changes on each merge to main. Newest first.
+
+## 2026-07-03
+
+- Updated [NeMo Guardrails](https://github.com/NVIDIA-NeMo/Guardrails) link (repo moved)
+- Updated [Presidio](https://github.com/data-privacy-stack/presidio) link (repo moved)
+- Updated [Strands Agents SDK](https://github.com/strands-agents/harness-sdk) link (repo moved)
+- Updated [Upsonic](https://github.com/Upsonic/Upsonic) link (repo moved)
+- Added [A2A](https://github.com/a2aproject/A2A) to 🔌 Protocols
+- Added [Agent S](https://github.com/simular-ai/Agent-S) to 🌐 Web & Computer Use Agents
+- Added [Arize Phoenix](https://github.com/Arize-ai/phoenix) to 📈 Observability
+- Added [FastMCP](https://github.com/PrefectHQ/fastmcp) to 🔌 Protocols
+- Added [Helicone](https://github.com/Helicone/helicone) to 📈 Observability
+- Added [Laminar](https://github.com/lmnr-ai/lmnr) to 📈 Observability
+- Added [Langfuse](https://github.com/langfuse/langfuse) to 📈 Observability
+- Added [LiveKit Agents](https://github.com/livekit/agents) to 🎙️ Voice Agents
+- Added [MCP Servers](https://github.com/modelcontextprotocol/servers) to 🔌 Protocols
+- Added [Model Context Protocol](https://github.com/modelcontextprotocol/modelcontextprotocol) to 🔌 Protocols
+- Added [OpenLLMetry](https://github.com/traceloop/openllmetry) to 📈 Observability
+- Added [Pipecat](https://github.com/pipecat-ai/pipecat) to 🎙️ Voice Agents
+- Added [Playwright MCP](https://github.com/microsoft/playwright-mcp) to 🌐 Web & Computer Use Agents
+- Added [Skyvern](https://github.com/Skyvern-AI/skyvern) to 🌐 Web & Computer Use Agents
+- Added [TEN Framework](https://github.com/TEN-framework/ten-framework) to 🎙️ Voice Agents
+- Added [UI-TARS Desktop](https://github.com/bytedance/UI-TARS-desktop) to 🌐 Web & Computer Use Agents
+
+## 2026-06-27
+
+- Added [Hephaestus](https://github.com/agentlas-ai/Hephaestus) to 🌟 Core Frameworks
+
+## 2026-06-23
+
+- Added [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) to 🌐 Web Agents
+
+## 2026-06-22
+
+- Added [ax](https://github.com/Necmttn/ax) to 📊 Evaluation
+
+## 2026-06-02
+
+- Added [LightAgent](https://github.com/wanxingai/LightAgent) to 🌟 Core Frameworks
+
+## 2026-06-01
+
+- Added [Polaxis](https://github.com/nishant6118/Polaxis-SDK-MCP) to 🔒 Security & Governance
+
+## 2026-05-31
+
+- Added [Garak](https://github.com/NVIDIA/garak) to 🔒 Security & Governance
+- Added [Guardrails AI](https://github.com/guardrails-ai/guardrails) to 🔒 Security & Governance
+- Added [LLM Guard](https://github.com/protectai/llm-guard) to 🔒 Security & Governance
+- Added [NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails) to 🔒 Security & Governance
+- Added [Presidio](https://github.com/microsoft/presidio) to 🔒 Security & Governance
+
+## 2026-05-23
+
+- Updated [Aider](https://github.com/Aider-AI/aider) link (repo moved)
+- Updated [CrewAI](https://github.com/crewAIInc/crewAI) link (repo moved)
+- Updated [Goose](https://github.com/aaif-goose/goose) link (repo moved)
+- Updated [LangChain.rb](https://github.com/patterns-ai-core/langchainrb) link (repo moved)
+- Updated [MetaGPT](https://github.com/FoundationAgents/MetaGPT) link (repo moved)
+- Updated [OpenHands](https://github.com/OpenHands/OpenHands) link (repo moved)
+- Updated [SWE-agent](https://github.com/SWE-agent/SWE-agent) link (repo moved)
+
+## 2026-05-10
+
+- Added [agenttrace](https://github.com/luoyuctl/agenttrace) to 📊 Evaluation

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re) [![Lint](https://github.com/NipunaRanasinghe/awesome-ai-agents/actions/workflows/lint.yml/badge.svg)](https://github.com/NipunaRanasinghe/awesome-ai-agents/actions/workflows/lint.yml) [![Check Links](https://github.com/NipunaRanasinghe/awesome-ai-agents/actions/workflows/links.yml/badge.svg)](https://github.com/NipunaRanasinghe/awesome-ai-agents/actions/workflows/links.yml) [![Last Commit](https://img.shields.io/github/last-commit/NipunaRanasinghe/awesome-ai-agents)](https://github.com/NipunaRanasinghe/awesome-ai-agents/commits/main) [![Contributors](https://img.shields.io/github/contributors/NipunaRanasinghe/awesome-ai-agents)](https://github.com/NipunaRanasinghe/awesome-ai-agents/pulse)
 
+[![Browse the list as a website](https://img.shields.io/badge/Browse_the_list_as_a_website-2ea44f?style=for-the-badge&logo=githubpages&logoColor=white)](https://nipunaranasinghe.github.io/awesome-ai-agents/)
+[![What's new](https://img.shields.io/badge/What%27s_new-Changelog-0a7bbc?style=for-the-badge&logo=keepachangelog&logoColor=white)](CHANGELOG.md)
+
 <!-- description -->
 
 _A curated list of frameworks, tools, and resources for building and deploying AI agents. From multi-agent systems to autonomous coding assistants, this repository covers the latest advancements in AI agent technology._
@@ -17,11 +20,6 @@ _A curated list of frameworks, tools, and resources for building and deploying A
 <a href="https://github.com/NipunaRanasinghe/awesome-ai-agents" target="_blank" rel="noopener noreferrer">
   <img src="resources/images/image.png" alt="Awesome AI Agents Logo">
 </a>
-
-<!-- website -->
-
-[![Browse the list as a website](https://img.shields.io/badge/Browse_the_list_as_a_website-2ea44f?style=for-the-badge&logo=githubpages&logoColor=white)](https://nipunaranasinghe.github.io/awesome-ai-agents/)
-[![What's new](https://img.shields.io/badge/What%27s_new-Changelog-0a7bbc?style=for-the-badge&logo=keepachangelog&logoColor=white)](CHANGELOG.md)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ _A curated list of frameworks, tools, and resources for building and deploying A
 
 <!-- website -->
 
-**[🌐 Browse this list as a website](https://nipunaranasinghe.github.io/awesome-ai-agents/)** • **[📆 What's new](CHANGELOG.md)**
+[![Browse the list as a website](https://img.shields.io/badge/Browse_the_list_as_a_website-2ea44f?style=for-the-badge&logo=githubpages&logoColor=white)](https://nipunaranasinghe.github.io/awesome-ai-agents/)
+[![What's new](https://img.shields.io/badge/What%27s_new-Changelog-0a7bbc?style=for-the-badge&logo=keepachangelog&logoColor=white)](CHANGELOG.md)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ _A curated list of frameworks, tools, and resources for building and deploying A
 
 <!-- website -->
 
-**[🌐 Browse this list as a website](https://nipunaranasinghe.github.io/awesome-ai-agents/)**
+**[🌐 Browse this list as a website](https://nipunaranasinghe.github.io/awesome-ai-agents/)** • **[📆 What's new](CHANGELOG.md)**
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re) [![Lint](https://github.com/NipunaRanasinghe/awesome-ai-agents/actions/workflows/lint.yml/badge.svg)](https://github.com/NipunaRanasinghe/awesome-ai-agents/actions/workflows/lint.yml) [![Check Links](https://github.com/NipunaRanasinghe/awesome-ai-agents/actions/workflows/links.yml/badge.svg)](https://github.com/NipunaRanasinghe/awesome-ai-agents/actions/workflows/links.yml) [![Last Commit](https://img.shields.io/github/last-commit/NipunaRanasinghe/awesome-ai-agents)](https://github.com/NipunaRanasinghe/awesome-ai-agents/commits/main) [![Contributors](https://img.shields.io/github/contributors/NipunaRanasinghe/awesome-ai-agents)](https://github.com/NipunaRanasinghe/awesome-ai-agents/pulse)
 
-[![Browse the list as a website](https://img.shields.io/badge/Browse_the_list_as_a_website-2ea44f?style=for-the-badge&logo=githubpages&logoColor=white)](https://nipunaranasinghe.github.io/awesome-ai-agents/)
-[![What's new](https://img.shields.io/badge/What%27s_new-Changelog-0a7bbc?style=for-the-badge&logo=keepachangelog&logoColor=white)](CHANGELOG.md)
-
 <!-- description -->
 
 _A curated list of frameworks, tools, and resources for building and deploying AI agents. From multi-agent systems to autonomous coding assistants, this repository covers the latest advancements in AI agent technology._
+
+<p>
+  <a href="https://nipunaranasinghe.github.io/awesome-ai-agents/"><img src="https://img.shields.io/badge/Browse_the_list_as_a_website-2ea44f?style=for-the-badge&logo=githubpages&logoColor=white" height="40" alt="Browse the list as a website"></a>&nbsp;&nbsp;<a href="CHANGELOG.md"><img src="https://img.shields.io/badge/What%27s_new-Changelog-0a7bbc?style=for-the-badge&logo=keepachangelog&logoColor=white" height="40" alt="What's new — Changelog"></a>
+</p>
 
 <!-- image -->
 


### PR DESCRIPTION
Adds a freshness signal to the repo: a `CHANGELOG.md` that is generated automatically, so it can never go stale.

**How it works**

- `.github/scripts/update_changelog.py` diffs `README.md` between two commits, extracts added and removed table entries, and prepends them under a date heading in `CHANGELOG.md`. Rows whose link is unchanged (formatting or description edits) are ignored; the same name appearing with a different URL is recorded as a link update (repo moved). Added entries are annotated with their section.
- `.github/workflows/changelog.yml` runs the script on every push to `main` that touches `README.md` and commits the result. The bot commit only touches `CHANGELOG.md`, so it cannot retrigger the workflow.
- `CHANGELOG.md` is backfilled from the last two months of history (10 README-changing merges) by running the script over each one, which also served as the test of the extraction logic.
- The README hero links to it ("📆 What's new").

Script is idempotent (re-running the same commit range adds no duplicate lines). `npx awesome-lint` passes.