### PR TITLE
Add PR template and sharpen README value proposition

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+<!-- Thanks for contributing! Please check the boxes below before submitting. -->
+
+## What does this PR do?
+
+<!-- Briefly describe the entry you're adding, updating, or removing. -->
+
+## Checklist
+
+- [ ] The project is actively maintained (updated in the last 6 months) and relevant to AI agents
+- [ ] It isn't already listed
+- [ ] The row follows the format: `| [Name](url) | ![](https://img.shields.io/github/stars/owner/repo) | One-line description |`
+- [ ] The stars badge `owner/repo` matches the link URL
+- [ ] Added to the correct section
+
+---
+
+⭐ If this list has been useful to you, consider starring the repo — it helps others discover it.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <!-- description -->
 
-_A curated list of frameworks, tools, and resources for building and deploying AI agents. From multi-agent systems to autonomous coding assistants, this repository covers the latest advancements in AI agent technology._
+_A curated, actively maintained directory of 100+ frameworks, tools, and resources for building AI agents — from multi-agent systems and autonomous coding assistants to memory, evaluation, and deployment. ⭐ Star it to keep the fast-moving AI agent ecosystem one click away._
 
 <!-- image -->
 


### PR DESCRIPTION
Two low-friction changes to convert readers/contributors into stargazers, without any coercive gating.

**1. Add `.github/pull_request_template.md`**
Doubles as a formatting checklist (actively-maintained, not-already-listed, row format, badge/link match, correct section) — which also reduces the common badge-mismatch bugs in incoming PRs — and ends with a single opt-in nudge shown at the moment of contribution:
> ⭐ If this list has been useful to you, consider starring the repo — it helps others discover it.

**2. Sharpen the above-the-fold README description**
Leads with a concrete hook (100+ entries, actively maintained, category spread) and folds a natural star reason into the first thing a reader sees. Uses "100+" rather than an exact count so it won't go stale.

awesome-lint passes.