### PR TITLE
Reuse a single Link Checker issue instead of opening duplicates

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -19,10 +19,22 @@ jobs:
         with:
           fail: false
 
-      - name: Create Issue From File
+      - name: Find existing report issue
+        id: existing
+        if: steps.lychee.outputs.exit_code != 0
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          num=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+            --label "automated issue" --search "Link Checker Report in:title" \
+            --json number --jq '.[0].number // ""')
+          echo "number=$num" >> "$GITHUB_OUTPUT"
+
+      - name: Create or Update Issue From File
         if: steps.lychee.outputs.exit_code != 0
         uses: peter-evans/create-issue-from-file@v5
         with:
           title: Link Checker Report
           content-filepath: ./lychee/out.md
           labels: report, automated issue
+          issue-number: ${{ steps.existing.outputs.number }}


### PR DESCRIPTION
## Problem
The daily `links.yml` (lychee) workflow calls `create-issue-from-file` unconditionally, so every run with a broken link opens a **new** "Link Checker Report" issue. This produced 36 duplicate open issues.

## Fix
Add a lookup step that finds the existing open report issue (title "Link Checker Report" + `automated issue` label) and passes its number to `create-issue-from-file`'s `issue-number` input:

- Issue exists → the step **updates** it in place with the fresh report.
- No open issue → `issue-number` is empty → exactly one new issue is created, which becomes the persistent one.

Result: at most one open Link Checker issue at a time.

## Notes
- No new permissions needed — the job already has `issues: write`, and the lookup uses the built-in `github.token` via `GH_TOKEN`.
- Cleanup of the existing 35 duplicates was done separately; #159 is kept open and will be the issue reused going forward.