### PR TITLE
Add Caesar to Research Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Agents designed for specific tasks or industries.
 | [DeerFlow](https://github.com/bytedance/deer-flow)              | ![](https://img.shields.io/github/stars/bytedance/deer-flow)        | Framework for deep research with web search and Python execution                                                           |
 | [Agon](https://github.com/AutoResearch-Factory/Agon)            | ![](https://img.shields.io/github/stars/AutoResearch-Factory/Agon)  | Prompt Economy orchestrator: reusable scientist/coder/auditor loops instead of per-task prompts, 18 roles, 10+ disciplines |
 | [AutoNumerics](https://github.com/Daviddjddu/Autonumerics)      | ![](https://img.shields.io/github/stars/Daviddjddu/Autonumerics)    | Writes, debugs, and validates classical PDE numerical solvers from plain-language problem descriptions                     |
-| [Caesar](https://github.com/jasonzliang/caesar-agent) | ![](https://img.shields.io/github/stars/jasonzliang/caesar-agent) | Builds a knowledge graph while exploring the web, then refines drafts via adversarial synthesis |
+| [Caesar](https://github.com/jasonzliang/caesar-agent)           | ![](https://img.shields.io/github/stars/jasonzliang/caesar-agent)   | Builds a knowledge graph while exploring the web, then refines drafts via adversarial synthesis                            |
 
 ### 🎨 Creative Agents
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Agents designed for specific tasks or industries.
 | [DeerFlow](https://github.com/bytedance/deer-flow)              | ![](https://img.shields.io/github/stars/bytedance/deer-flow)        | Framework for deep research with web search and Python execution                                                           |
 | [Agon](https://github.com/AutoResearch-Factory/Agon)            | ![](https://img.shields.io/github/stars/AutoResearch-Factory/Agon)  | Prompt Economy orchestrator: reusable scientist/coder/auditor loops instead of per-task prompts, 18 roles, 10+ disciplines |
 | [AutoNumerics](https://github.com/Daviddjddu/Autonumerics)      | ![](https://img.shields.io/github/stars/Daviddjddu/Autonumerics)    | Writes, debugs, and validates classical PDE numerical solvers from plain-language problem descriptions                     |
+| [Caesar](https://github.com/jasonzliang/caesar-agent) | ![](https://img.shields.io/github/stars/jasonzliang/caesar-agent) | Builds a knowledge graph while exploring the web, then refines drafts via adversarial synthesis |
 
 ### 🎨 Creative Agents
 


### PR DESCRIPTION
## What does this PR do?

Adds [Caesar](https://github.com/jasonzliang/caesar-agent) as one row at the bottom of **Research Agents**, alongside GPT Researcher and Storm.

```md
| [Caesar](https://github.com/jasonzliang/caesar-agent) | ![](https://img.shields.io/github/stars/jasonzliang/caesar-agent) | Builds a knowledge graph while exploring the web, then refines drafts via adversarial synthesis |
```

Caesar builds a knowledge graph while exploring the web, then refines drafts recurrently, each one producing an orthogonal challenge against its own gaps before merging. Apache-2.0, [PyPI](https://pypi.org/project/caesar-agent/) 0.4.17, paper [arXiv:2604.20855](https://arxiv.org/abs/2604.20855). I am the author.

## Checklist

- [x] The project is actively maintained (updated in the last 6 months) and relevant to AI agents
- [x] It isn't already listed
- [x] The row follows the format: `| [Name](url) | ![](https://img.shields.io/github/stars/owner/repo) | One-line description |`
- [x] The stars badge `owner/repo` matches the link URL
- [x] Added to the correct section
