### PR TITLE
Add P2PCLAW and CAJAL research agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ Agents designed for specific tasks or industries.
 | [Agon](https://github.com/AutoResearch-Factory/Agon)            | ![](https://img.shields.io/github/stars/AutoResearch-Factory/Agon)  | Prompt Economy orchestrator: reusable scientist/coder/auditor loops instead of per-task prompts, 18 roles, 10+ disciplines |
 | [AutoNumerics](https://github.com/Daviddjddu/Autonumerics)      | ![](https://img.shields.io/github/stars/Daviddjddu/Autonumerics)    | Writes, debugs, and validates classical PDE numerical solvers from plain-language problem descriptions                     |
 | [Caesar](https://github.com/jasonzliang/caesar-agent)           | ![](https://img.shields.io/github/stars/jasonzliang/caesar-agent)   | Builds a knowledge graph while exploring the web, then refines drafts via adversarial synthesis                            |
-| [P2PCLAW](https://github.com/Agnuxo1/OpenCLAW-P2P)              | ![](https://img.shields.io/github/stars/Agnuxo1/OpenCLAW-P2P)       | Decentralized P2P agent swarm for open scientific research       |
-| [CAJAL](https://github.com/Agnuxo1/CAJAL)                       | ![](https://img.shields.io/github/stars/Agnuxo1/CAJAL)              | Local scientific paper generation agent with IMRaD structure and citations |
+| [P2PCLAW](https://github.com/Agnuxo1/OpenCLAW-P2P)              | ![](https://img.shields.io/github/stars/Agnuxo1/OpenCLAW-P2P)       | Decentralized P2P agent swarm for open scientific research                                                                 |
+| [CAJAL](https://github.com/Agnuxo1/CAJAL)                       | ![](https://img.shields.io/github/stars/Agnuxo1/CAJAL)              | Local scientific paper generation agent with IMRaD structure and citations                                                 |
 
 ### 🎨 Creative Agents
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ Agents designed for specific tasks or industries.
 | [Agon](https://github.com/AutoResearch-Factory/Agon)            | ![](https://img.shields.io/github/stars/AutoResearch-Factory/Agon)  | Prompt Economy orchestrator: reusable scientist/coder/auditor loops instead of per-task prompts, 18 roles, 10+ disciplines |
 | [AutoNumerics](https://github.com/Daviddjddu/Autonumerics)      | ![](https://img.shields.io/github/stars/Daviddjddu/Autonumerics)    | Writes, debugs, and validates classical PDE numerical solvers from plain-language problem descriptions                     |
 | [Caesar](https://github.com/jasonzliang/caesar-agent)           | ![](https://img.shields.io/github/stars/jasonzliang/caesar-agent)   | Builds a knowledge graph while exploring the web, then refines drafts via adversarial synthesis                            |
+| [P2PCLAW](https://github.com/Agnuxo1/OpenCLAW-P2P)              | ![](https://img.shields.io/github/stars/Agnuxo1/OpenCLAW-P2P)       | Decentralized P2P agent swarm for open scientific research       |
+| [CAJAL](https://github.com/Agnuxo1/CAJAL)                       | ![](https://img.shields.io/github/stars/Agnuxo1/CAJAL)              | Local scientific paper generation agent with IMRaD structure and citations |
 
 ### 🎨 Creative Agents
 


### PR DESCRIPTION
## Summary
- Add P2PCLAW as a decentralized multi-agent coordination framework.
- Add CAJAL as a local-first autonomous scientific research agent.

The entries follow the repository owner's exact request in #89 and are submitted together in one focused PR.

## Validation
- Rebased on current `main`
- Only the two requested README entries are added
- `git diff --check` passes

Closes #89