### PR TITLE
Add Atomic Agent to Coding Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,20 +108,21 @@ Agents designed for specific tasks or industries.
 
 ### 💻 Coding Agents
 
-| Name                                                      | Stars                                                             | Description                                                             |
-| --------------------------------------------------------- | ----------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| [SWE-agent](https://github.com/SWE-agent/SWE-agent)       | ![](https://img.shields.io/github/stars/SWE-agent/SWE-agent)      | AI agent for software engineering tasks                                 |
-| [GPT Pilot](https://github.com/Pythagora-io/gpt-pilot)    | ![](https://img.shields.io/github/stars/Pythagora-io/gpt-pilot)   | Assists in writing and debugging code                                   |
-| [OpenHands](https://github.com/OpenHands/OpenHands)       | ![](https://img.shields.io/github/stars/OpenHands/OpenHands)      | Open-source AI software development agents (formerly OpenDevin)         |
-| [Devika](https://github.com/stitionai/devika)             | ![](https://img.shields.io/github/stars/stitionai/devika)         | Agentic AI Software Engineer that writes code from natural instructions |
-| [Aider](https://github.com/Aider-AI/aider)                | ![](https://img.shields.io/github/stars/Aider-AI/aider)           | AI pair programming in terminal                                         |
-| [Plandex](https://github.com/plandex-ai/plandex)          | ![](https://img.shields.io/github/stars/plandex-ai/plandex)       | AI coding engine for complex projects                                   |
-| [TaskWeaver](https://github.com/microsoft/TaskWeaver)     | ![](https://img.shields.io/github/stars/microsoft/TaskWeaver)     | Code-first agent framework for analytical tasks                         |
-| [Gemini CLI](https://github.com/google-gemini/gemini-cli) | ![](https://img.shields.io/github/stars/google-gemini/gemini-cli) | Open-source AI agent bringing Gemini to the terminal with MCP support   |
-| [AgenticSeek](https://github.com/Fosowl/agenticSeek)      | ![](https://img.shields.io/github/stars/Fosowl/agenticSeek)       | Fully local autonomous agent that browses web and codes without APIs    |
-| [Cline](https://github.com/cline/cline)                   | ![](https://img.shields.io/github/stars/cline/cline)              | Autonomous coding agent in VS Code with MCP, browser use, and terminal  |
-| [Goose](https://github.com/aaif-goose/goose)              | ![](https://img.shields.io/github/stars/aaif-goose/goose)         | Open-source extensible AI agent by Block for engineering tasks          |
-| [bolt.diy](https://github.com/stackblitz-labs/bolt.diy)   | ![](https://img.shields.io/github/stars/stackblitz-labs/bolt.diy) | AI-powered full-stack web development in the browser with 19+ LLMs      |
+| Name                                                         | Stars                                                              | Description                                                             |
+| ------------------------------------------------------------ | ------------------------------------------------------------------ | ----------------------------------------------------------------------- |
+| [SWE-agent](https://github.com/SWE-agent/SWE-agent)          | ![](https://img.shields.io/github/stars/SWE-agent/SWE-agent)       | AI agent for software engineering tasks                                 |
+| [GPT Pilot](https://github.com/Pythagora-io/gpt-pilot)       | ![](https://img.shields.io/github/stars/Pythagora-io/gpt-pilot)    | Assists in writing and debugging code                                   |
+| [OpenHands](https://github.com/OpenHands/OpenHands)          | ![](https://img.shields.io/github/stars/OpenHands/OpenHands)       | Open-source AI software development agents (formerly OpenDevin)         |
+| [Devika](https://github.com/stitionai/devika)                | ![](https://img.shields.io/github/stars/stitionai/devika)          | Agentic AI Software Engineer that writes code from natural instructions |
+| [Aider](https://github.com/Aider-AI/aider)                   | ![](https://img.shields.io/github/stars/Aider-AI/aider)            | AI pair programming in terminal                                         |
+| [Plandex](https://github.com/plandex-ai/plandex)             | ![](https://img.shields.io/github/stars/plandex-ai/plandex)        | AI coding engine for complex projects                                   |
+| [TaskWeaver](https://github.com/microsoft/TaskWeaver)        | ![](https://img.shields.io/github/stars/microsoft/TaskWeaver)      | Code-first agent framework for analytical tasks                         |
+| [Gemini CLI](https://github.com/google-gemini/gemini-cli)    | ![](https://img.shields.io/github/stars/google-gemini/gemini-cli)  | Open-source AI agent bringing Gemini to the terminal with MCP support   |
+| [AgenticSeek](https://github.com/Fosowl/agenticSeek)         | ![](https://img.shields.io/github/stars/Fosowl/agenticSeek)        | Fully local autonomous agent that browses web and codes without APIs    |
+| [Cline](https://github.com/cline/cline)                      | ![](https://img.shields.io/github/stars/cline/cline)               | Autonomous coding agent in VS Code with MCP, browser use, and terminal  |
+| [Goose](https://github.com/aaif-goose/goose)                 | ![](https://img.shields.io/github/stars/aaif-goose/goose)          | Open-source extensible AI agent by Block for engineering tasks          |
+| [bolt.diy](https://github.com/stackblitz-labs/bolt.diy)      | ![](https://img.shields.io/github/stars/stackblitz-labs/bolt.diy)  | AI-powered full-stack web development in the browser with 19+ LLMs      |
+| [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) | ![](https://img.shields.io/github/stars/AtomicBot-ai/atomic-agent) | Local-first CLI and TUI coding agent, open-weight models, 56 tools, MCP |
 
 ### 🔬 Research Agents
 


### PR DESCRIPTION
## What does this PR do?

Hi! I'm the CPO of Atomic Agent. Thanks for putting this list together, it's genuinely one of the more carefully curated agent directories out there, and our team would be thrilled to be part of it.

Adds [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) as one row at the bottom of **Coding Agents**, alongside Aider and Gemini CLI.

```md
| [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) | ![](https://img.shields.io/github/stars/AtomicBot-ai/atomic-agent) | Local-first CLI and TUI coding agent, open-weight models, 56 tools, MCP |
```

Atomic Agent is a local-first coding assistant with both a CLI and a TUI (built on React and ink). It runs open-weight models entirely on your machine through a llama.cpp fork, so no account or API key is needed to install and run it. It ships 56 built-in tools (browser, filesystem, git, memory, vision), supports MCP, has a five-layer local memory system, and runs on macOS, Linux, and Windows.

MIT licensed, ~2k stars, actively developed. Install: `curl -fsSL https://atomicagent.io/install | sh`

More: [site](https://atomicagent.io) · [docs](https://atomicagent.io/docs) · [Discord](https://discord.gg/Us7qXtDGw) · [X](https://x.com/atomicagent_io)

Two notes on the diff, both intentional:

- The added row is slightly wider than the previous widest row, so I re-padded the whole Coding Agents table to keep the pipes aligned, in the same spirit as the alignment commits on the recent Orkas and Caesar PRs. Every other line in the diff is whitespace only, `git diff -w` shows just the new row and the separator.
- `npx awesome-lint` passes on this branch. The separator row needed to match the new column widths, otherwise `remark-lint:table-pipe-alignment` fails.

Disclosure: I'm affiliated with AtomicBot-ai, which maintains Atomic Agent. Happy to adjust the wording, shorten the description, or move the row if you'd prefer it in a different section.

## Checklist

- [x] The project is actively maintained (updated in the last 6 months) and relevant to AI agents
- [x] It isn't already listed
- [x] The row follows the format: `| [Name](url) | ![](https://img.shields.io/github/stars/owner/repo) | One-line description |`
- [x] The stars badge `owner/repo` matches the link URL
- [x] Added to the correct section
