### PR TITLE
Add Portable Handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Tools and systems for managing AI agents.
 | [Tree Ring Memory](https://github.com/TerminallyLazy/Tree-Ring-Memory) | ![](https://img.shields.io/github/stars/TerminallyLazy/Tree-Ring-Memory) | Local-first CLI/TUI for agent memory recall, forgetting, audit, and consolidation |
 | [ChromaDB](https://github.com/chroma-core/chroma)                      | ![](https://img.shields.io/github/stars/chroma-core/chroma)              | Vector DB for memory/context                                                      |
 | [Weaviate](https://github.com/weaviate/weaviate)                       | ![](https://img.shields.io/github/stars/weaviate/weaviate)               | Scalable vector DB for semantic memory                                            |
+| [Portable Handoff](https://github.com/legoambarish/portable-handoff)   | ![](https://img.shields.io/github/stars/legoambarish/portable-handoff)  | Local-first CLI for handing off coding-agent session context between tools        |
 
 ### 📊 Evaluation
 


### PR DESCRIPTION
## What does this PR do?

Adds Portable Handoff to Agent Operations > Memory: a local-first CLI and Markdown/JSON capsule format for carrying coding-agent session context (goal, decisions, corrections, next action) between chats and tools. Standard-library-only Python, no server, no account, no API key.

## Checklist

- [x] The project is actively maintained (updated in the last 6 months) and relevant to AI agents
- [x] It isn't already listed
- [x] The row follows the format: `| [Name](url) | ![](https://img.shields.io/github/stars/owner/repo) | One-line description |`
- [x] The stars badge `owner/repo` matches the link URL
- [x] Added to the correct section