### PR TITLE
Add OfferHuntCrew to Job & Career Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ _A curated, actively maintained directory of 100+ frameworks, tools, and resourc
   - [💻 Coding Agents](#-coding-agents)
   - [🔬 Research Agents](#-research-agents)
   - [🎨 Creative Agents](#-creative-agents)
+  - [💼 Job & Career Agents](#-job--career-agents)
   - [🌐 Web & Computer Use Agents](#-web--computer-use-agents)
   - [🗣️ Programming Language Agents](#-programming-language-agents)
   - [🎙️ Voice Agents](#-voice-agents)
@@ -143,6 +144,14 @@ Agents designed for specific tasks or industries.
 | -------------------------------------------------- | ------------------------------------------------------------ | --------------------------------------- |
 | [ShortGPT](https://github.com/RayVentura/ShortGPT) | ![](https://img.shields.io/github/stars/RayVentura/ShortGPT) | Short-form video generation agent       |
 | [AI-town](https://github.com/a16z-infra/ai-town)   | ![](https://img.shields.io/github/stars/a16z-infra/ai-town)  | Virtual world simulation with AI agents |
+
+### 💼 Job & Career Agents
+
+Agents specialized for job hunting, career planning and recruitment.
+
+| Name                                                         | Stars                                                            | Description                                                                                                |
+| ------------------------------------------------------------ | ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| [OfferHuntCrew](https://github.com/C571467648/offerhuntcrew) | ![](https://img.shields.io/github/stars/C571467648/offerhuntcrew) | Open-source multi-agent AI team for job seekers — 5 AI roles (Architect / Career Coach / Job Scout / Interview Mentor / Resume Optimizer) covering job intelligence, application tracking, visual dashboards, todo management, interview prep and resume optimization |
 
 ### 🌐 Web & Computer Use Agents
 


### PR DESCRIPTION
Add [OfferHuntCrew](https://github.com/C571467648/offerhuntcrew) to a new **Job & Career Agents** subcategory under Specialized Agents.

OfferHuntCrew is an open-source multi-agent AI system for job seekers. 5 AI roles (Architect / Career Coach / Job Scout / Interview Mentor / Resume Optimizer) collaborate through shared folders to guide users through autumn/spring recruitment — covering job intelligence gathering, application tracking with visual dashboards, daily/weekly todo management, interview prep and resume optimization. Pure HTML dashboards, double-click to open, no server needed.

Per CONTRIBUTING.md: added a new subcategory (existing ones don't fit), and updated the table of contents accordingly.