### PR TITLE
feat: add SandBase Harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Frameworks for building and managing AI agents.
 | [Orkas](https://github.com/Orkas-AI/Orkas)                                 | ![](https://img.shields.io/github/stars/Orkas-AI/Orkas)                   | Local-first workspace coordinating specialist AI agents across projects                                                                                                        |
 | [Better Agent](https://github.com/ofekron/better-agent)                    | ![](https://img.shields.io/github/stars/ofekron/better-agent)             | Source-available workspace for running and supervising Claude, Codex, and Gemini coding-agent sessions                                                                         |
 | [fractal](https://github.com/plasma-ai/fractal)                            | ![](https://img.shields.io/github/stars/plasma-ai/fractal)                | Hierarchical coding-agent runtime with bounded autonomous loops, recursive delegation, isolated Git worktrees, persistent SQLite state, and live operator controls             |
+| [SandBase Harness](https://github.com/sandbaseai/sandbase-harness)         | ![](https://img.shields.io/github/stars/sandbaseai/sandbase-harness)      | Local-first, self-hosted TypeScript runtime and MCP bridge with persistent sessions, governed tools, approvals, credentials, memory, audit/replay, and selectable execution backends |
 
 [agentlas-stars]: https://img.shields.io/github/stars/agentlas-ai/Agentlas-OS
 


### PR DESCRIPTION
Adds SandBase Harness to Core Frameworks.

- Uses the repository's existing dynamic GitHub stars badge format
- Describes the local-first self-hosted runtime, MCP bridge, governance, memory, audit/replay, and selectable backends
- Links the public upstream repository; no endorsement or security certification is implied

Project: https://github.com/sandbaseai/sandbase-harness