### PR TITLE
Add Agent Coordinator

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Frameworks for building and managing AI agents.
 | [Orkas](https://github.com/Orkas-AI/Orkas)                                 | ![](https://img.shields.io/github/stars/Orkas-AI/Orkas)                   | Local-first workspace coordinating specialist AI agents across projects                                                                                                        |
 | [Better Agent](https://github.com/ofekron/better-agent)                    | ![](https://img.shields.io/github/stars/ofekron/better-agent)             | Source-available workspace for running and supervising Claude, Codex, and Gemini coding-agent sessions                                                                         |
 | [fractal](https://github.com/plasma-ai/fractal)                            | ![](https://img.shields.io/github/stars/plasma-ai/fractal)                | Hierarchical coding-agent runtime with bounded autonomous loops, recursive delegation, isolated Git worktrees, persistent SQLite state, and live operator controls             |
+| [Agent Coordinator](https://github.com/alanhoff/agent-coordinator)         | ![](https://img.shields.io/github/stars/alanhoff/agent-coordinator)       | Per-user Codex skill for resumable work graphs, declared write scopes, and repeatable completion checks                                                                         |
 
 [agentlas-stars]: https://img.shields.io/github/stars/agentlas-ai/Agentlas-OS
 


### PR DESCRIPTION
## What does this PR do?

Adds Agent Coordinator to **Core Frameworks**. The section includes tools for managing coordinated agent work; the entry identifies this project more narrowly as a per-user Codex skill.

The skill records complex work as a local graph, records declared write scopes for each node, and reruns authored checks before completion.

## Checklist

- [x] The project is actively maintained (updated in the last 6 months) and relevant to AI agents
- [x] It isn't already listed
- [x] The row follows the format: `| [Name](url) | ![](https://img.shields.io/github/stars/owner/repo) | One-line description |`
- [x] The stars badge `owner/repo` matches the link URL
- [x] Added to the correct section

## Validation

- No matching repository URL or open pull request was found.
- The project is public, MIT-licensed, and documents installation and use.
- The entry and badge both point to `alanhoff/agent-coordinator`.

## Disclosure

I maintain Agent Coordinator. I prepared this submission with Codex and reviewed every claim against the linked source.
