### PR TITLE
Add AI Weekly to agent newsletters

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ Join the conversation and stay updated on AI agent developments.
 
 | Name                        | Link                                                | Description                 |
 | --------------------------- | --------------------------------------------------- | --------------------------- |
+| AI Weekly                   | [Subscribe](https://aiweekly.co/)                    | Models, agents, research, and policy ranked from expert signals |
 | The Batch (DeepLearning.AI) | [Subscribe](https://www.deeplearning.ai/the-batch/) | Weekly AI industry insights |
 
 ---


### PR DESCRIPTION
Adds AI Weekly to the newsletters table. Its expert-signal ranking and coverage of models, agents, research, and policy make it relevant for builders following the agent ecosystem.\n\nDisclosure: I am the founder of AI Weekly and am submitting this resource directly.