### PR TITLE
Add YYLO to Core Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Frameworks for building and managing AI agents.
 | [Orkas](https://github.com/Orkas-AI/Orkas)                                 | ![](https://img.shields.io/github/stars/Orkas-AI/Orkas)                   | Local-first workspace coordinating specialist AI agents across projects                                                                                                        |
 | [Better Agent](https://github.com/ofekron/better-agent)                    | ![](https://img.shields.io/github/stars/ofekron/better-agent)             | Source-available workspace for running and supervising Claude, Codex, and Gemini coding-agent sessions                                                                         |
 | [fractal](https://github.com/plasma-ai/fractal)                            | ![](https://img.shields.io/github/stars/plasma-ai/fractal)                | Hierarchical coding-agent runtime with bounded autonomous loops, recursive delegation, isolated Git worktrees, persistent SQLite state, and live operator controls             |
+| [YYLO](https://github.com/yylo-dev/yylo)                                   | ![](https://img.shields.io/github/stars/yylo-dev/yylo)                    | Command-line orchestrator for coding agents with typed task, validation, merge, and release-readiness boundaries, a dedicated branch/worktree, and risk-based merge review     |
 
 [agentlas-stars]: https://img.shields.io/github/stars/agentlas-ai/Agentlas-OS
 


### PR DESCRIPTION
## What does this PR do?

Adds YYLO to **Core Frameworks**. YYLO is a command-line orchestrator for coding agents: each task gets a dedicated branch/worktree behind typed task, validation, merge, and release-readiness boundaries, and a merge queue owns risk-based review before anything lands. It installs via npm (`@yylo/cli`) and orchestrates Pi and Codex subagents.

## Checklist

- [x] The project is actively maintained (updated in the last 6 months) and relevant to AI agents
- [x] It isn't already listed
- [x] The row follows the format: `| [Name](url) | ![](https://img.shields.io/github/stars/owner/repo) | One-line description |`
- [x] The stars badge `yylo-dev/yylo` matches the link URL
- [x] Added to the correct section

## Validation

- Repository and shields.io badge URLs verified.
- The Markdown table remains pipe-aligned (row padded to the section's existing column widths).
- `git diff --check` passes.
- Actively maintained: daily pushes since January 2026, MIT-licensed, 57★, installable via `npm i -g @yylo/cli`.

Placed in Core Frameworks alongside the coding-agent runtime/orchestration entries (fractal, Orkas, Better Agent, Hivekeep); happy to re-file to 💻 Coding Agents if you prefer.

Project disclosure: I'm on the YYLO team; this PR was prepared with an AI coding agent and reviewed by me before submission.
